### PR TITLE
Fix build with mtl-2.3

### DIFF
--- a/src/Database/Persist/Documentation.hs
+++ b/src/Database/Persist/Documentation.hs
@@ -151,6 +151,7 @@ module Database.Persist.Documentation
   , markdownTableRenderer
   ) where
 
+import           Control.Monad                           (forM, join)
 import           Control.Monad.Writer
 import qualified Data.Char                               as Char
 import           Data.Foldable                           (fold, toList)


### PR DESCRIPTION
mtl-2.3 no longer reexports `Control.Monad`